### PR TITLE
Set abortable on first event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fix: `Composer.onProgress` should set `abortable` on the first event (based on `SpeechRecognition.audioStart` event), by [@compulim](https://github.com/compulim) in PR [#5](https://github.com/compulim/react-dictate-button/pull/5)
+
 ## [1.2.0] - 2019-12-03
 ### Added
 - Support unabortable speech recognition, by [@compulim](https://github.com/compulim) in PR [#4](https://github.com/compulim/react-dictate-button/pull/4).

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -102,7 +102,7 @@ export default class Composer extends React.Component {
     // Web Speech API does not emit "result" when nothing is heard, and Chrome does not emit "nomatch" event.
     // Because we emitted onProgress, we should emit "dictate" if not error, so they works in pair.
     this.emitDictateOnEnd = true;
-    this.props.onProgress && this.props.onProgress({});
+    this.props.onProgress && this.props.onProgress({ abortable: abortable(this.recognition) });
   }
 
   handleEnd() {


### PR DESCRIPTION
## Changelog

### Fixed

- Fix: `Composer.onProgress` should set `abortable` on the first event (based on `SpeechRecognition.audioStart` event), by [@compulim](https://github.com/compulim) in PR [#5](https://github.com/compulim/react-dictate-button/pull/5)
