### PR TITLE
Workaround zone.js bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fix [#12](https://github.com/compulim/react-dictate-button/issues/12): Workaround [Angular/zone.js bug](https://github.com/angular/angular/issues/31750) by not using Symbol.iterator for iterable objects, by [@compulim](https://github.com/compulim) in PR [#13](https://github.com/compulim/react-dictate-button/pull/13)
+
 ## [1.2.1] - 2019-12-04
+
 ### Fixed
 - Fix: `Composer.onProgress` should set `abortable` on the first event (based on `SpeechRecognition.audioStart` event), by [@compulim](https://github.com/compulim) in PR [#5](https://github.com/compulim/react-dictate-button/pull/5)
 
 ## [1.2.0] - 2019-12-03
+
 ### Added
 - Support unabortable speech recognition, by [@compulim](https://github.com/compulim) in PR [#4](https://github.com/compulim/react-dictate-button/pull/4).
 
@@ -19,10 +24,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Move `lerna bootstrap` from hoisted to local
 
 ## [1.1.3] - 2018-07-19
+
 ### Fixed
 - Fix: move [`memoize-one`](https://npmjs.com/package/memoize-one) to production dependencies
 
 ## [1.1.2] - 2018-06-29
+
 ### Fixed
 - Fix: `Composer.speechRecognition`/`speechGrammarList` should not be required
 
@@ -30,10 +37,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add: `onClick` prop, can use `preventDefault` to stop speech recognition from starting
 
 ## [1.1.1] - 2018-06-29
+
 ### Fixed
 - fix: `extra` prop not passed to `<Composer>`
 
 ## [1.1.0] - 2018-06-29
+
 ### Added
 - Added `extra` prop to copy to `SpeechRecognition`
 
@@ -41,5 +50,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bump to [`memoize-one@4.0.0`](https://npmjs.com/package/memoize-one/v/4.0.0)
 
 ## [1.0.0] - 2018-06-26
+
 ### Added
 - Initial release

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -136,12 +136,16 @@ export default class Composer extends React.Component {
     const { results: rawResults } = event;
 
     if (rawResults.length) {
-      const results = [].map.call(rawResults, ([firstAlt]) => ({
-        confidence: firstAlt.confidence,
-        transcript: firstAlt.transcript
-      }));
+      const results = [].map.call(rawResults, alts => {
+        const firstAlt = alts[0];
 
-      const [first] = rawResults;
+        return {
+          confidence: firstAlt.confidence,
+          transcript: firstAlt.transcript
+        };
+      });
+
+      const first = rawResults[0];
 
       if (first.isFinal) {
         this.emitDictateOnEnd = false;


### PR DESCRIPTION
### Fixed

- Fix [#12](https://github.com/compulim/react-dictate-button/issues/12): Workaround [Angular/zone.js bug](https://github.com/angular/angular/issues/31750) by not using Symbol.iterator for iterable objects, by [@compulim](https://github.com/compulim) in PR [#13](https://github.com/compulim/react-dictate-button/pull/13)
