### PR TITLE
Add polyfills for Internet Explorer 11

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,4 @@
 
 > Please list each individual specific change in this pull request.
 
--
+- 

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
+    "react-app-polyfill": "^2.0.0",
     "react-dictate-button": "^0.0.0-0",
     "react-scripts": "4.0.3",
     "web-vitals": "^1.1.2"

--- a/packages/playground/src/index.js
+++ b/packages/playground/src/index.js
@@ -1,3 +1,6 @@
+import 'react-app-polyfill/ie11';
+import 'react-app-polyfill/stable';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';


### PR DESCRIPTION
## Description

Although Web Speech API, WebRTC, and Web Audio are not supported by Internet Explorer 11, this package should not break any web apps depending on this package.

## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

## Specific changes

> Please list each individual specific change in this pull request.

- Added polyfills in `playground` for IE11
- Removed EOF new line in `.github/pull_request_template.md`