### PR TITLE
Allow stop after onDictate regardless abortability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed [#65](https://github.com/compulim/react-dictate-button/issues/65). Setting `started` to `false` after `onDictate` callback should succeed even on an unabortable recognition, by [@compulim](https://github.com/compulim), in PR [#66](https://github.com/compulim/react-dictate-button/pull/66)
+
 ## [2.0.0] - 2021-05-16
 
 ### Breaking changes

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -80,10 +80,12 @@ const Composer = ({
       }
 
       recognitionRef.current = undefined;
-
       setReadyState(0);
 
-      emitDictateOnEndRef.current && onDictateRef.current && onDictateRef.current({ type: 'dictate' });
+      if (emitDictateOnEndRef.current) {
+        onDictateRef.current && onDictateRef.current({ type: 'dictate' });
+        emitDictateOnEndRef.current = false;
+      }
     },
     [emitDictateOnEndRef, onDictateRef, recognitionRef, setReadyState]
   );
@@ -143,7 +145,11 @@ const Composer = ({
         const first = rawResults[0];
 
         if (first.isFinal) {
-          emitDictateOnEndRef.current = false;
+          // After "onDictate" callback, the caller should be able to set "started" to false on an unabortable recognition.
+          // TODO: Add test for fortification.
+          recognitionRef.current = undefined;
+          setReadyState(0);
+
           onDictateRef.current && onDictateRef.current({ result: results[0], type: 'dictate' });
         } else {
           onProgressRef.current &&
@@ -151,7 +157,7 @@ const Composer = ({
         }
       }
     },
-    [emitDictateOnEndRef, onDictateRef, onProgressRef, recognitionRef]
+    [onDictateRef, onProgressRef, recognitionRef, setReadyState]
   );
 
   const handleStart = useCallback(


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Fixed

- Fixed [#65](https://github.com/compulim/react-dictate-button/issues/65). Setting `started` to `false` after `onDictate` callback should succeed even on an unabortable recognition, by [@compulim](https://github.com/compulim), in PR [#66](https://github.com/compulim/react-dictate-button/pull/66)

## Specific changes

> Please list each individual specific change in this pull request.

- Immediately before `onDictate` callback, unattach the `speechRecognition` instance, so setting `started` to `false` (a.k.a. stopping) should not trigger "cannot abort an unabortable recognition" exception