### PR TITLE
Rectify constructor for `SpeechRecognitionResult` and `SpeechRecognitionResultList`

### DIFF
--- a/packages/integration-test/importDefault.test.mjs
+++ b/packages/integration-test/importDefault.test.mjs
@@ -49,9 +49,9 @@ test('simple scenario', async () => {
 
     speechRecognition.dispatchEvent(
       new SpeechRecognitionEvent('result', {
-        results: new SpeechRecognitionResultList([
-          new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9, 'Hello, World!')], true)
-        ])
+        results: new SpeechRecognitionResultList(
+          SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9, 'Hello, World!'))
+        )
       })
     );
 

--- a/packages/integration-test/requireDefault.test.mjs
+++ b/packages/integration-test/requireDefault.test.mjs
@@ -49,9 +49,9 @@ test('simple scenario', async () => {
 
     speechRecognition.dispatchEvent(
       new SpeechRecognitionEvent('result', {
-        results: new SpeechRecognitionResultList([
-          new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9, 'Hello, World!')], true)
-        ])
+        results: new SpeechRecognitionResultList(
+          SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9, 'Hello, World!'))
+        )
       })
     );
 

--- a/packages/mocked-speech-recognition/src/SpeechRecognitionEvent.ts
+++ b/packages/mocked-speech-recognition/src/SpeechRecognitionEvent.ts
@@ -12,7 +12,7 @@ export default class SpeechRecognitionEvent extends Event {
 
     this.#resultIndex = eventInitDict.resultIndex ?? 0;
     this.#results =
-      'results' in eventInitDict && eventInitDict.results ? eventInitDict.results : new SpeechRecognitionResultList([]);
+      'results' in eventInitDict && eventInitDict.results ? eventInitDict.results : new SpeechRecognitionResultList();
   }
 
   #resultIndex: number;

--- a/packages/mocked-speech-recognition/src/SpeechRecognitionResult.ts
+++ b/packages/mocked-speech-recognition/src/SpeechRecognitionResult.ts
@@ -3,10 +3,12 @@
 
 import SpeechRecognitionAlternative from './SpeechRecognitionAlternative.ts';
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export default interface SpeechRecognitionResult {
   fromFinalized(...items: SpeechRecognitionAlternative[]): SpeechRecognitionResult;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export default class SpeechRecognitionResult
   extends Array<SpeechRecognitionAlternative>
   implements SpeechRecognitionResult

--- a/packages/mocked-speech-recognition/src/SpeechRecognitionResult.ts
+++ b/packages/mocked-speech-recognition/src/SpeechRecognitionResult.ts
@@ -1,9 +1,20 @@
+// Supports export class and interface at the same time.
+/* eslint-disable import/export */
+
 import SpeechRecognitionAlternative from './SpeechRecognitionAlternative.ts';
 
-export default class SpeechRecognitionResult extends Array<SpeechRecognitionAlternative> {
+export default interface SpeechRecognitionResult {
+  fromFinalized(...items: SpeechRecognitionAlternative[]): SpeechRecognitionResult;
+}
+
+export default class SpeechRecognitionResult
+  extends Array<SpeechRecognitionAlternative>
+  implements SpeechRecognitionResult
+{
   constructor(...args: SpeechRecognitionAlternative[]);
   constructor(arrayLength?: number);
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(...args: any[]) {
     super(...args);
 
@@ -27,9 +38,4 @@ export default class SpeechRecognitionResult extends Array<SpeechRecognitionAlte
 
     return result;
   }
-}
-
-export default interface SpeechRecognitionResult {
-  new (...args: any[]): SpeechRecognitionResult;
-  fromFinalized(items: SpeechRecognitionAlternative[]): SpeechRecognitionResult;
 }

--- a/packages/mocked-speech-recognition/src/SpeechRecognitionResult.ts
+++ b/packages/mocked-speech-recognition/src/SpeechRecognitionResult.ts
@@ -1,13 +1,16 @@
 import SpeechRecognitionAlternative from './SpeechRecognitionAlternative.ts';
 
 export default class SpeechRecognitionResult extends Array<SpeechRecognitionAlternative> {
-  constructor(items: SpeechRecognitionAlternative[], isFinal: boolean | undefined) {
-    super(...items);
+  constructor(...args: SpeechRecognitionAlternative[]);
+  constructor(arrayLength?: number);
 
-    this.#isFinal = !!isFinal;
+  constructor(...args: any[]) {
+    super(...args);
+
+    this.#isFinal = false;
   }
 
-  #isFinal: boolean;
+  #isFinal: boolean = false;
 
   item(index: number): SpeechRecognitionAlternative | undefined {
     return this[index];
@@ -16,4 +19,17 @@ export default class SpeechRecognitionResult extends Array<SpeechRecognitionAlte
   get isFinal(): boolean {
     return this.#isFinal;
   }
+
+  static fromFinalized(...items: SpeechRecognitionAlternative[]): SpeechRecognitionResult {
+    const result = new SpeechRecognitionResult(...items);
+
+    result.#isFinal = true;
+
+    return result;
+  }
+}
+
+export default interface SpeechRecognitionResult {
+  new (...args: any[]): SpeechRecognitionResult;
+  fromFinalized(items: SpeechRecognitionAlternative[]): SpeechRecognitionResult;
 }

--- a/packages/mocked-speech-recognition/src/SpeechRecognitionResultList.ts
+++ b/packages/mocked-speech-recognition/src/SpeechRecognitionResultList.ts
@@ -4,6 +4,7 @@ export default class SpeechRecognitionResultList extends Array<SpeechRecognition
   constructor(...args: SpeechRecognitionResult[]);
   constructor(arrayLength?: number);
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(...args: any[]) {
     super(...args);
   }

--- a/packages/mocked-speech-recognition/src/SpeechRecognitionResultList.ts
+++ b/packages/mocked-speech-recognition/src/SpeechRecognitionResultList.ts
@@ -1,8 +1,11 @@
 import SpeechRecognitionResult from './SpeechRecognitionResult.ts';
 
 export default class SpeechRecognitionResultList extends Array<SpeechRecognitionResult> {
-  constructor(items: SpeechRecognitionResult[]) {
-    super(...items);
+  constructor(...args: SpeechRecognitionResult[]);
+  constructor(arrayLength?: number);
+
+  constructor(...args: any[]) {
+    super(...args);
   }
 
   item(index: number): SpeechRecognitionResult | undefined {

--- a/packages/react-dictate-button/__tests__/continuous.spec.tsx
+++ b/packages/react-dictate-button/__tests__/continuous.spec.tsx
@@ -87,9 +87,9 @@ describe('with continuous mode', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 0,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.009999999776482582, 'test')], false)
-          ])
+          results: new SpeechRecognitionResultList(
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.009999999776482582, 'test'))
+          )
         })
       );
     });
@@ -110,9 +110,9 @@ describe('with continuous mode', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 0,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.009999999776482582, 'testing')], false)
-          ])
+          results: new SpeechRecognitionResultList(
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.009999999776482582, 'testing'))
+          )
         })
       );
     });
@@ -133,9 +133,9 @@ describe('with continuous mode', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 0,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.966937243938446, 'testing')], true)
-          ])
+          results: new SpeechRecognitionResultList(
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.966937243938446, 'testing'))
+          )
         })
       );
     });
@@ -157,10 +157,10 @@ describe('with continuous mode', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 1,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.966937243938446, 'testing')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.009999999776482582, ' one')], false)
-          ])
+          results: new SpeechRecognitionResultList(
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.966937243938446, 'testing')),
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.009999999776482582, ' one'))
+          )
         })
       );
     });
@@ -181,10 +181,10 @@ describe('with continuous mode', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 1,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.966937243938446, 'testing')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9035850167274475, ' one')], true)
-          ])
+          results: new SpeechRecognitionResultList(
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.966937243938446, 'testing')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9035850167274475, ' one'))
+          )
         })
       );
     });
@@ -203,11 +203,11 @@ describe('with continuous mode', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 2,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.966937243938446, 'testing')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9035850167274475, ' one')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.009999999776482582, ' two')], false)
-          ])
+          results: new SpeechRecognitionResultList(
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.966937243938446, 'testing')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9035850167274475, ' one')),
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.009999999776482582, ' two'))
+          )
         })
       );
     });
@@ -228,11 +228,11 @@ describe('with continuous mode', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 2,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.966937243938446, 'testing')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9035850167274475, ' one')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.8551138043403625, ' two')], true)
-          ])
+          results: new SpeechRecognitionResultList(
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.966937243938446, 'testing')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9035850167274475, ' one')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.8551138043403625, ' two'))
+          )
         })
       );
     });
@@ -254,12 +254,12 @@ describe('with continuous mode', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 3,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.966937243938446, 'testing')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9035850167274475, ' one')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.8551138043403625, ' two')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.009999999776482582, ' three')], false)
-          ])
+          results: new SpeechRecognitionResultList(
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.966937243938446, 'testing')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9035850167274475, ' one')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.8551138043403625, ' two')),
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.009999999776482582, ' three'))
+          )
         })
       );
     });
@@ -283,12 +283,12 @@ describe('with continuous mode', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 3,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.966937243938446, 'testing')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9035850167274475, ' one')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.8551138043403625, ' two')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9290534257888794, ' three')], true)
-          ])
+          results: new SpeechRecognitionResultList(
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.966937243938446, 'testing')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9035850167274475, ' one')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.8551138043403625, ' two')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9290534257888794, ' three'))
+          )
         })
       );
     });
@@ -310,13 +310,13 @@ describe('with continuous mode', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 4,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.966937243938446, 'testing')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9035850167274475, ' one')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.8551138043403625, ' two')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9290534257888794, ' three')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.009999999776482582, ' test')], false)
-          ])
+          results: new SpeechRecognitionResultList(
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.966937243938446, 'testing')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9035850167274475, ' one')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.8551138043403625, ' two')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9290534257888794, ' three')),
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.009999999776482582, ' test'))
+          )
         })
       );
     });
@@ -340,13 +340,13 @@ describe('with continuous mode', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 4,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.966937243938446, 'testing')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9035850167274475, ' one')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.8551138043403625, ' two')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9290534257888794, ' three')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.009999999776482582, ' testing')], false)
-          ])
+          results: new SpeechRecognitionResultList(
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.966937243938446, 'testing')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9035850167274475, ' one')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.8551138043403625, ' two')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9290534257888794, ' three')),
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.009999999776482582, ' testing'))
+          )
         })
       );
     });
@@ -370,13 +370,13 @@ describe('with continuous mode', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 4,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.966937243938446, 'testing')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9035850167274475, ' one')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.8551138043403625, ' two')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9290534257888794, ' three')], true),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9721954464912415, ' testing')], true)
-          ])
+          results: new SpeechRecognitionResultList(
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.966937243938446, 'testing')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9035850167274475, ' one')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.8551138043403625, ' two')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9290534257888794, ' three')),
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9721954464912415, ' testing'))
+          )
         })
       );
     });

--- a/packages/react-dictate-button/__tests__/continuousModeNotSupported.spec.tsx
+++ b/packages/react-dictate-button/__tests__/continuousModeNotSupported.spec.tsx
@@ -85,9 +85,9 @@ describe('not honoring continuous mode', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 0,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.009999999776482582, 'test')], false)
-          ])
+          results: new SpeechRecognitionResultList(
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.009999999776482582, 'test'))
+          )
         })
       );
     });
@@ -108,9 +108,9 @@ describe('not honoring continuous mode', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 0,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.009999999776482582, 'testing')], false)
-          ])
+          results: new SpeechRecognitionResultList(
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.009999999776482582, 'testing'))
+          )
         })
       );
     });
@@ -131,9 +131,9 @@ describe('not honoring continuous mode', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 0,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.8999999761581421, 'testing')], true)
-          ])
+          results: new SpeechRecognitionResultList(
+            SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.8999999761581421, 'testing'))
+          )
         })
       );
     });

--- a/packages/react-dictate-button/__tests__/multipleInterims.spec.tsx
+++ b/packages/react-dictate-button/__tests__/multipleInterims.spec.tsx
@@ -86,9 +86,9 @@ describe('with multiple non-finalized interims', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 0,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.009999999776482582, 'test')], false)
-          ])
+          results: new SpeechRecognitionResultList(
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.009999999776482582, 'test'))
+          )
         })
       );
     });
@@ -109,9 +109,9 @@ describe('with multiple non-finalized interims', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 0,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.009999999776482582, 'testing')], false)
-          ])
+          results: new SpeechRecognitionResultList(
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.009999999776482582, 'testing'))
+          )
         })
       );
     });
@@ -132,9 +132,9 @@ describe('with multiple non-finalized interims', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 0,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.8999999761581421, 'testing')], false)
-          ])
+          results: new SpeechRecognitionResultList(
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.8999999761581421, 'testing'))
+          )
         })
       );
     });
@@ -155,10 +155,10 @@ describe('with multiple non-finalized interims', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 0,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.8999999761581421, 'testing')], false),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.009999999776482582, ' one')], false)
-          ])
+          results: new SpeechRecognitionResultList(
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.8999999761581421, 'testing')),
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.009999999776482582, ' one'))
+          )
         })
       );
     });
@@ -180,10 +180,10 @@ describe('with multiple non-finalized interims', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 0,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.8999999761581421, 'testing')], false),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.009999999776482582, ' one two')], false)
-          ])
+          results: new SpeechRecognitionResultList(
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.8999999761581421, 'testing')),
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.009999999776482582, ' one two'))
+          )
         })
       );
     });
@@ -205,10 +205,10 @@ describe('with multiple non-finalized interims', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 0,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.8999999761581421, 'testing')], false),
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.009999999776482582, ' 1 2 3')], false)
-          ])
+          results: new SpeechRecognitionResultList(
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.8999999761581421, 'testing')),
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.009999999776482582, ' 1 2 3'))
+          )
         })
       );
     });
@@ -230,13 +230,10 @@ describe('with multiple non-finalized interims', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 0,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.8999999761581421, 'testing')], false),
-            new SpeechRecognitionResult(
-              [new SpeechRecognitionAlternative(0.009999999776482582, ' one two three')],
-              false
-            )
-          ])
+          results: new SpeechRecognitionResultList(
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.8999999761581421, 'testing')),
+            new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.009999999776482582, ' one two three'))
+          )
         })
       );
     });
@@ -258,12 +255,11 @@ describe('with multiple non-finalized interims', () => {
       speechRecognition.dispatchEvent(
         new SpeechRecognitionEvent('result', {
           resultIndex: 0,
-          results: new SpeechRecognitionResultList([
-            new SpeechRecognitionResult(
-              [new SpeechRecognitionAlternative(0.5359774827957153, 'testing one two three')],
-              true
+          results: new SpeechRecognitionResultList(
+            SpeechRecognitionResult.fromFinalized(
+              new SpeechRecognitionAlternative(0.5359774827957153, 'testing one two three')
             )
-          ])
+          )
         })
       );
     });
@@ -271,9 +267,10 @@ describe('with multiple non-finalized interims', () => {
     expect(onDictate).toHaveBeenCalledTimes(1);
     expect(onProgress).toHaveBeenCalledTimes(0);
     expect(onDictate.mock.calls[0][0]).toHaveProperty('type', 'dictate');
-    expect(onDictate.mock.calls[0][0]).toHaveProperty('result',
-      { confidence: 0.5359774827957153, transcript: 'testing one two three' }
-    );
+    expect(onDictate.mock.calls[0][0]).toHaveProperty('result', {
+      confidence: 0.5359774827957153,
+      transcript: 'testing one two three'
+    });
 
     // ---
 

--- a/packages/react-dictate-button/__tests__/simple.checkbox.spec.tsx
+++ b/packages/react-dictate-button/__tests__/simple.checkbox.spec.tsx
@@ -83,9 +83,9 @@ describe('simple scenario for <DictateCheckbox>', () => {
             speechRecognition.dispatchEvent(
               new SpeechRecognitionEvent('result', {
                 resultIndex: 0,
-                results: new SpeechRecognitionResultList([
-                  new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9, 'Hello, World!')], true)
-                ])
+                results: new SpeechRecognitionResultList(
+                  SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9, 'Hello, World!'))
+                )
               })
             );
           })

--- a/packages/react-dictate-button/__tests__/simple.spec.tsx
+++ b/packages/react-dictate-button/__tests__/simple.spec.tsx
@@ -80,9 +80,9 @@ describe('simple scenario', () => {
             speechRecognition.dispatchEvent(
               new SpeechRecognitionEvent('result', {
                 resultIndex: 0,
-                results: new SpeechRecognitionResultList([
-                  new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9, 'Hello, World!')], true)
-                ])
+                results: new SpeechRecognitionResultList(
+                  SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9, 'Hello, World!'))
+                )
               })
             );
           })

--- a/packages/react-dictate-button/__tests__/stopAfterOnDictate.spec.tsx
+++ b/packages/react-dictate-button/__tests__/stopAfterOnDictate.spec.tsx
@@ -59,9 +59,9 @@ describe('with SpeechRecognition object without abort() stop after onDictate', (
         speechRecognition.dispatchEvent(
           new SpeechRecognitionEvent('result', {
             resultIndex: 0,
-            results: new SpeechRecognitionResultList([
-              new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9, 'Hello, World!')], true)
-            ])
+            results: new SpeechRecognitionResultList(
+              SpeechRecognitionResult.fromFinalized(new SpeechRecognitionAlternative(0.9, 'Hello, World!'))
+            )
           })
         );
 

--- a/packages/react-dictate-button/__tests__/stopWithoutFinalize.spec.tsx
+++ b/packages/react-dictate-button/__tests__/stopWithoutFinalize.spec.tsx
@@ -72,9 +72,9 @@ describe('end without "result" event with "isFinal" set to true', () => {
         speechRecognition.dispatchEvent(
           new SpeechRecognitionEvent('result', {
             resultIndex: 0,
-            results: new SpeechRecognitionResultList([
-              new SpeechRecognitionResult([new SpeechRecognitionAlternative(0.9, 'Hello, World!')], false)
-            ])
+            results: new SpeechRecognitionResultList(
+              new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.9, 'Hello, World!'))
+            )
           })
         );
 


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

(No changelog for test changes.)

## Specific changes

> Please list each individual specific change in this pull request.

- Update mocked `SpeechRecognitionResult` and `SpeechRecognitionResultList` to match the constructor of `Array`

```ts
class MyArray extends Array {
  constructor(items: []) {
    super(...items);
  }
}

new MyArray([1, 2, 3]).map(value => console.log(value)); // Would fail
```

When `Array.prototype.map()` is called, it will call the constructor again. Since the constructor parameters does not match `Array.prototype.constructor`, it would fail with a weird error.
