### PR TITLE
Allow undefined `SpeechRecognitionResultEvent.resultIndex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Breaking changes are indicated by 💥.
 
 ## [Unreleased]
 
+### Added
+
+- Works with Web Speech API provider without `resultIndex` in `SpeechRecognitiveResultEvent`, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/compulim/react-dictate-button/pull/XXX)
+
 ### Changed
 
 - Reduced React version requirement from 16.9.0 to 16.8.6, by [@compulim](https://github.com/compulim), in PR [#83](https://github.com/compulim/react-dictate-button/pull/83)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Breaking changes are indicated by 💥.
 
 ### Added
 
-- Works with Web Speech API provider without `resultIndex` in `SpeechRecognitiveResultEvent`, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/compulim/react-dictate-button/pull/XXX)
+- Works with Web Speech API provider without `resultIndex` in `SpeechRecognitionResultEvent`, by [@compulim](https://github.com/compulim), in PR [#86](https://github.com/compulim/react-dictate-button/pull/86)
 
 ### Changed
 

--- a/packages/react-dictate-button/src/Composer.tsx
+++ b/packages/react-dictate-button/src/Composer.tsx
@@ -206,9 +206,11 @@ const Composer = ({
       }
 
       if (rawResults.length) {
+        // web-speech-cognitive-services does not emit "resultIndex".
+
         // Destructuring breaks Angular due to a bug in Zone.js.
         // eslint-disable-next-line prefer-destructuring
-        const rawResult = rawResults[resultIndex];
+        const rawResult = rawResults[resultIndex ?? rawResults.length - 1];
 
         if (rawResult?.isFinal) {
           if (!continuousRef.current) {


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Added

- Works with Web Speech API provider without `resultIndex` in `SpeechRecognitionResultEvent`, by [@compulim](https://github.com/compulim), in PR [#86](https://github.com/compulim/react-dictate-button/pull/86)

## Specific changes

> Please list each individual specific change in this pull request.

- If `SpeechRecognitionResultEvent.resultIndex` is `undefined`, assume it points to the last results