### PR TITLE
Fixed `dictate` event should dispatch before `end` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Breaking changes are indicated by 💥.
 
 ### Fixed
 
-- Fixed `dictate` event should dispatch before `end` event, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/compulim/react-dictate-button/pull/XXX)
+- Fixed `dictate` event should dispatch before `end` event, by [@compulim](https://github.com/compulim), in PR [#87](https://github.com/compulim/react-dictate-button/pull/87)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Breaking changes are indicated by 💥.
 ### Fixed
 
 - Fixed `dictate` event should dispatch before `end` event, by [@compulim](https://github.com/compulim), in PR [#87](https://github.com/compulim/react-dictate-button/pull/87)
+- Logics should relies on `SpeechRecognition.continuous` property than `continuous` props, by [@compulim](https://github.com/compulim), in PR [#87](https://github.com/compulim/react-dictate-button/pull/87)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Breaking changes are indicated by 💥.
 
 - Works with Web Speech API provider without `resultIndex` in `SpeechRecognitionResultEvent`, by [@compulim](https://github.com/compulim), in PR [#86](https://github.com/compulim/react-dictate-button/pull/86)
 
+### Fixed
+
+- Fixed `dictate` event should dispatch before `end` event, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/compulim/react-dictate-button/pull/XXX)
+
 ### Changed
 
 - Reduced React version requirement from 16.9.0 to 16.8.6, by [@compulim](https://github.com/compulim), in PR [#83](https://github.com/compulim/react-dictate-button/pull/83)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Breaking changes are indicated by 💥.
 ### Fixed
 
 - Fixed `dictate` event should dispatch before `end` event, by [@compulim](https://github.com/compulim), in PR [#87](https://github.com/compulim/react-dictate-button/pull/87)
-- Logics should relies on `SpeechRecognition.continuous` property than `continuous` props, by [@compulim](https://github.com/compulim), in PR [#87](https://github.com/compulim/react-dictate-button/pull/87)
+- Fixed [#84](https://github.com/compulim/react-dictate-button/issues/84). Logics should relies on `SpeechRecognition.continuous` property than `continuous` props, by [@compulim](https://github.com/compulim), in PR [#87](https://github.com/compulim/react-dictate-button/pull/87)
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4841,6 +4841,20 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/babel-plugin-transform-define": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-define/-/babel-plugin-transform-define-2.1.4.tgz",
+      "integrity": "sha512-NN9xFmyNvr4swPZkRWy+RZZoV0yHhPk/WoxpuIvcVkTyYf0xy/JTQeZVbVGX8hyJ0/NKKuxnt4BZz9No7BziVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.11",
+        "traverse": "0.6.6"
+      },
+      "engines": {
+        "node": ">= 8.x.x"
+      }
+    },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
@@ -8819,6 +8833,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -10892,6 +10913,13 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -11738,6 +11766,7 @@
         "@types/node": "^22.7.5",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.2",
+        "babel-plugin-transform-define": "^2.1.4",
         "core-js": "^3.38.1",
         "esbuild": "^0.24.0",
         "jest": "^29.7.0",
@@ -14913,6 +14942,16 @@
         "@babel/helper-define-polyfill-provider": "^0.6.3"
       }
     },
+    "babel-plugin-transform-define": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-define/-/babel-plugin-transform-define-2.1.4.tgz",
+      "integrity": "sha512-NN9xFmyNvr4swPZkRWy+RZZoV0yHhPk/WoxpuIvcVkTyYf0xy/JTQeZVbVGX8hyJ0/NKKuxnt4BZz9No7BziVA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11",
+        "traverse": "0.6.6"
+      }
+    },
     "babel-preset-current-node-syntax": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
@@ -17626,6 +17665,12 @@
         "p-locate": "^4.1.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -18223,6 +18268,7 @@
         "@types/node": "^22.7.5",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.2",
+        "babel-plugin-transform-define": "^2.1.4",
         "core-js": "^3.38.1",
         "esbuild": "^0.24.0",
         "jest": "^29.7.0",
@@ -19172,6 +19218,12 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw==",
+      "dev": true
     },
     "tree-kill": {
       "version": "1.2.2",

--- a/packages/react-dictate-button/__tests__/continuous.spec.tsx
+++ b/packages/react-dictate-button/__tests__/continuous.spec.tsx
@@ -97,7 +97,9 @@ describe('with continuous mode', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(0);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onProgress.mock.calls[0][0]).toHaveProperty('type', 'progress');
     expect(onProgress.mock.calls[0][0]).toHaveProperty('results', [
       { confidence: 0.009999999776482582, transcript: 'test' }
@@ -120,7 +122,9 @@ describe('with continuous mode', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(0);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onProgress.mock.calls[0][0]).toHaveProperty('type', 'progress');
     expect(onProgress.mock.calls[0][0]).toHaveProperty('results', [
       { confidence: 0.009999999776482582, transcript: 'testing' }
@@ -143,7 +147,9 @@ describe('with continuous mode', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(1);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(0);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onDictate.mock.calls[0][0]).toHaveProperty('type', 'dictate');
     expect(onDictate.mock.calls[0][0]).toHaveProperty('result', {
       confidence: 0.966937243938446,
@@ -168,7 +174,9 @@ describe('with continuous mode', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(0);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onProgress.mock.calls[0][0]).toHaveProperty('type', 'progress');
     expect(onProgress.mock.calls[0][0]).toHaveProperty('results', [
       { confidence: 0.009999999776482582, transcript: ' one' }
@@ -192,7 +200,9 @@ describe('with continuous mode', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(1);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(0);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onDictate.mock.calls[0][0]).toHaveProperty('type', 'dictate');
     expect(onDictate.mock.calls[0][0]).toHaveProperty('result', { confidence: 0.9035850167274475, transcript: ' one' });
 
@@ -215,7 +225,9 @@ describe('with continuous mode', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(0);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onProgress.mock.calls[0][0]).toHaveProperty('type', 'progress');
     expect(onProgress.mock.calls[0][0]).toHaveProperty('results', [
       { confidence: 0.009999999776482582, transcript: ' two' }
@@ -240,7 +252,9 @@ describe('with continuous mode', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(1);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(0);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onDictate.mock.calls[0][0]).toHaveProperty('type', 'dictate');
     expect(onDictate.mock.calls[0][0]).toHaveProperty('result', {
       confidence: 0.8551138043403625,
@@ -267,7 +281,9 @@ describe('with continuous mode', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(0);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onProgress.mock.calls[0][0]).toHaveProperty('type', 'progress');
     expect(onProgress.mock.calls[0][0]).toHaveProperty('results', [
       {
@@ -296,7 +312,9 @@ describe('with continuous mode', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(1);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(0);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onDictate.mock.calls[0][0]).toHaveProperty('type', 'dictate');
     expect(onDictate.mock.calls[0][0]).toHaveProperty('result', {
       confidence: 0.9290534257888794,
@@ -324,7 +342,9 @@ describe('with continuous mode', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(0);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onProgress.mock.calls[0][0]).toHaveProperty('type', 'progress');
     expect(onProgress.mock.calls[0][0]).toHaveProperty('results', [
       {
@@ -354,7 +374,9 @@ describe('with continuous mode', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(0);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onProgress.mock.calls[0][0]).toHaveProperty('type', 'progress');
     expect(onProgress.mock.calls[0][0]).toHaveProperty('results', [
       {
@@ -384,7 +406,9 @@ describe('with continuous mode', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(1);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(0);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onDictate.mock.calls[0][0]).toHaveProperty('type', 'dictate');
     expect(onDictate.mock.calls[0][0]).toHaveProperty('result', {
       confidence: 0.9721954464912415,

--- a/packages/react-dictate-button/__tests__/continuousModeNotSupported.spec.tsx
+++ b/packages/react-dictate-button/__tests__/continuousModeNotSupported.spec.tsx
@@ -67,6 +67,9 @@ describe('not honoring continuous mode', () => {
     expect(onProgress).toHaveBeenCalledTimes(0);
     expect(start).toHaveBeenCalledTimes(1);
 
+    // Web Speech provider does not honor continuous mode.
+    speechRecognition.continuous = false;
+
     act(() => {
       speechRecognition.dispatchEvent(new Event('start', {}));
       speechRecognition.dispatchEvent(new Event('audiostart', {}));
@@ -74,6 +77,9 @@ describe('not honoring continuous mode', () => {
       speechRecognition.dispatchEvent(new Event('speechstart', {}));
     });
 
+    expect(onDictate).toHaveBeenCalledTimes(0);
+    expect(onEnd).toHaveBeenCalledTimes(0);
+    expect(onProgress).toHaveBeenCalledTimes(1);
     expect(onStart).toHaveBeenCalledTimes(1);
 
     onStart.mockReset();
@@ -95,7 +101,9 @@ describe('not honoring continuous mode', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(0);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onProgress.mock.calls[0][0]).toHaveProperty('type', 'progress');
     expect(onProgress.mock.calls[0][0]).toHaveProperty('results', [
       { confidence: 0.009999999776482582, transcript: 'test' }
@@ -118,7 +126,9 @@ describe('not honoring continuous mode', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(0);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onProgress.mock.calls[0][0]).toHaveProperty('type', 'progress');
     expect(onProgress.mock.calls[0][0]).toHaveProperty('results', [
       { confidence: 0.009999999776482582, transcript: 'testing' }
@@ -141,7 +151,9 @@ describe('not honoring continuous mode', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(1);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(0);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onDictate.mock.calls[0][0]).toHaveProperty('type', 'dictate');
     expect(onDictate.mock.calls[0][0]).toHaveProperty('result', {
       confidence: 0.8999999761581421,

--- a/packages/react-dictate-button/__tests__/multipleInterims.spec.tsx
+++ b/packages/react-dictate-button/__tests__/multipleInterims.spec.tsx
@@ -96,7 +96,9 @@ describe('with multiple non-finalized interims', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(0);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onProgress.mock.calls[0][0]).toHaveProperty('type', 'progress');
     expect(onProgress.mock.calls[0][0]).toHaveProperty('results', [
       { confidence: 0.009999999776482582, transcript: 'test' }
@@ -119,7 +121,9 @@ describe('with multiple non-finalized interims', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(0);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onProgress.mock.calls[0][0]).toHaveProperty('type', 'progress');
     expect(onProgress.mock.calls[0][0]).toHaveProperty('results', [
       { confidence: 0.009999999776482582, transcript: 'testing' }
@@ -142,7 +146,9 @@ describe('with multiple non-finalized interims', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(0);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onProgress.mock.calls[0][0]).toHaveProperty('type', 'progress');
     expect(onProgress.mock.calls[0][0]).toHaveProperty('results', [
       { confidence: 0.8999999761581421, transcript: 'testing' }
@@ -166,7 +172,9 @@ describe('with multiple non-finalized interims', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(0);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onProgress.mock.calls[0][0]).toHaveProperty('type', 'progress');
     expect(onProgress.mock.calls[0][0]).toHaveProperty('results', [
       { confidence: 0.8999999761581421, transcript: 'testing' },
@@ -191,7 +199,9 @@ describe('with multiple non-finalized interims', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(0);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onProgress.mock.calls[0][0]).toHaveProperty('type', 'progress');
     expect(onProgress.mock.calls[0][0]).toHaveProperty('results', [
       { confidence: 0.8999999761581421, transcript: 'testing' },
@@ -216,7 +226,9 @@ describe('with multiple non-finalized interims', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(0);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onProgress.mock.calls[0][0]).toHaveProperty('type', 'progress');
     expect(onProgress.mock.calls[0][0]).toHaveProperty('results', [
       { confidence: 0.8999999761581421, transcript: 'testing' },
@@ -241,7 +253,9 @@ describe('with multiple non-finalized interims', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(0);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onProgress.mock.calls[0][0]).toHaveProperty('type', 'progress');
     expect(onProgress.mock.calls[0][0]).toHaveProperty('results', [
       { confidence: 0.8999999761581421, transcript: 'testing' },
@@ -267,7 +281,9 @@ describe('with multiple non-finalized interims', () => {
     });
 
     expect(onDictate).toHaveBeenCalledTimes(1);
+    expect(onEnd).toHaveBeenCalledTimes(0);
     expect(onProgress).toHaveBeenCalledTimes(0);
+    expect(onStart).toHaveBeenCalledTimes(0);
     expect(onDictate.mock.calls[0][0]).toHaveProperty('type', 'dictate');
     expect(onDictate.mock.calls[0][0]).toHaveProperty('result', {
       confidence: 0.5359774827957153,

--- a/packages/react-dictate-button/__tests__/simple.checkbox.spec.tsx
+++ b/packages/react-dictate-button/__tests__/simple.checkbox.spec.tsx
@@ -13,6 +13,7 @@ import {
 
 describe('simple scenario for <DictateCheckbox>', () => {
   let constructSpeechRecognition: jest.Mock<SpeechRecognition, []>;
+  let eventNames: string[];
   let onDictate: jest.Mock<ReturnType<DictateEventHandler>, Parameters<DictateEventHandler>, undefined>;
   let onEnd: jest.Mock<ReturnType<EndEventHandler>, Parameters<EndEventHandler>, undefined>;
   let onStart: jest.Mock<ReturnType<StartEventHandler>, Parameters<StartEventHandler>, undefined>;
@@ -27,9 +28,17 @@ describe('simple scenario for <DictateCheckbox>', () => {
       return speechRecognition;
     });
 
-    onDictate = jest.fn();
-    onEnd = jest.fn();
-    onStart = jest.fn();
+    eventNames = [];
+
+    onDictate = jest.fn<ReturnType<DictateEventHandler>, Parameters<DictateEventHandler>, undefined>(() =>
+      eventNames.push('dictate')
+    );
+
+    onEnd = jest.fn<ReturnType<EndEventHandler>, Parameters<EndEventHandler>, undefined>(() => eventNames.push('end'));
+
+    onStart = jest.fn<ReturnType<StartEventHandler>, Parameters<StartEventHandler>, undefined>(() =>
+      eventNames.push('start')
+    );
 
     render(
       <DictateCheckbox
@@ -104,6 +113,9 @@ describe('simple scenario for <DictateCheckbox>', () => {
             ));
         });
 
+        test('onStart() should not been called again', () => expect(onStart).toHaveBeenCalledTimes(1));
+        test('onEnd() should not be called', () => expect(onEnd).toHaveBeenCalledTimes(0));
+
         describe('when end events are dispatched', () => {
           beforeEach(() => {
             act(() => {
@@ -117,6 +129,7 @@ describe('simple scenario for <DictateCheckbox>', () => {
           test('onStart() should not be called again', () => expect(onStart).toHaveBeenCalledTimes(1));
           test('onEnd() should be called', () => expect(onEnd).toHaveBeenCalledTimes(1));
 
+          test('events should appear in right order', () => expect(eventNames).toEqual(['start', 'dictate', 'end']));
           test('should be unchecked', () =>
             expect(screen.getByText('Click me').querySelector('input')).toHaveProperty('checked', false));
         });

--- a/packages/react-dictate-button/__tests__/simple.spec.tsx
+++ b/packages/react-dictate-button/__tests__/simple.spec.tsx
@@ -13,6 +13,7 @@ import {
 
 describe('simple scenario', () => {
   let constructSpeechRecognition: jest.Mock<SpeechRecognition, []>;
+  let eventNames: string[];
   let onDictate: jest.Mock<ReturnType<DictateEventHandler>, Parameters<DictateEventHandler>, undefined>;
   let onEnd: jest.Mock<ReturnType<EndEventHandler>, Parameters<EndEventHandler>, undefined>;
   let onStart: jest.Mock<ReturnType<StartEventHandler>, Parameters<StartEventHandler>, undefined>;
@@ -27,9 +28,17 @@ describe('simple scenario', () => {
       return speechRecognition;
     });
 
-    onDictate = jest.fn();
-    onEnd = jest.fn();
-    onStart = jest.fn();
+    eventNames = [];
+
+    onDictate = jest.fn<ReturnType<DictateEventHandler>, Parameters<DictateEventHandler>, undefined>(() =>
+      eventNames.push('dictate')
+    );
+
+    onEnd = jest.fn<ReturnType<EndEventHandler>, Parameters<EndEventHandler>, undefined>(() => eventNames.push('end'));
+
+    onStart = jest.fn<ReturnType<StartEventHandler>, Parameters<StartEventHandler>, undefined>(() =>
+      eventNames.push('start')
+    );
 
     render(
       <DictateButton
@@ -101,6 +110,9 @@ describe('simple scenario', () => {
             ));
         });
 
+        test('onStart() should not been called again', () => expect(onStart).toHaveBeenCalledTimes(1));
+        test('onEnd() should not be called', () => expect(onEnd).toHaveBeenCalledTimes(0));
+
         describe('when end events are dispatched', () => {
           beforeEach(() => {
             act(() => {
@@ -113,6 +125,8 @@ describe('simple scenario', () => {
 
           test('onStart() should not be called again', () => expect(onStart).toHaveBeenCalledTimes(1));
           test('onEnd() should have been called once', () => expect(onEnd).toHaveBeenCalledTimes(1));
+
+          test('events should appear in right order', () => expect(eventNames).toEqual(['start', 'dictate', 'end']));
         });
       });
     });

--- a/packages/react-dictate-button/jest.config.json
+++ b/packages/react-dictate-button/jest.config.json
@@ -5,26 +5,15 @@
     "\\.[jt]sx?$": [
       "babel-jest",
       {
+        "plugins": [["babel-plugin-transform-define", { "IS_DEVELOPMENT": true }]],
         "presets": [
-          [
-            "@babel/preset-react",
-            {
-              "runtime": "classic"
-            }
-          ],
-          [
-            "@babel/preset-typescript",
-            {
-              "allowDeclareFields": true
-            }
-          ],
+          ["@babel/preset-react", { "runtime": "classic" }],
+          ["@babel/preset-typescript", { "allowDeclareFields": true }],
           [
             "@babel/preset-env",
             {
               "modules": "commonjs",
-              "targets": {
-                "node": "18"
-              }
+              "targets": { "node": "20" }
             }
           ]
         ],

--- a/packages/react-dictate-button/package.json
+++ b/packages/react-dictate-button/package.json
@@ -123,6 +123,7 @@
     "@types/node": "^22.7.5",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.2",
+    "babel-plugin-transform-define": "^2.1.4",
     "core-js": "^3.38.1",
     "esbuild": "^0.24.0",
     "jest": "^29.7.0",

--- a/packages/react-dictate-button/src/private/assert.ts
+++ b/packages/react-dictate-button/src/private/assert.ts
@@ -1,0 +1,9 @@
+declare global {
+  var IS_DEVELOPMENT: boolean;
+}
+
+export default function assert(truthy: boolean) {
+  if (IS_DEVELOPMENT && !truthy) {
+    throw new Error('Assertion failed.');
+  }
+}

--- a/packages/react-dictate-button/src/private/assert.ts
+++ b/packages/react-dictate-button/src/private/assert.ts
@@ -1,5 +1,5 @@
 declare global {
-  var IS_DEVELOPMENT: boolean;
+  const IS_DEVELOPMENT: boolean;
 }
 
 export default function assert(truthy: boolean) {

--- a/packages/react-dictate-button/tsup.config.ts
+++ b/packages/react-dictate-button/tsup.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig([
   {
+    define: { IS_DEVELOPMENT: 'false' },
     dts: true,
     entry: {
       'react-dictate-button': './src/index.ts',


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Fixed

- Fixed `dictate` event should dispatch before `end` event, by [@compulim](https://github.com/compulim), in PR [#87](https://github.com/compulim/react-dictate-button/pull/87)
- Fixed [#84](https://github.com/compulim/react-dictate-button/issues/84). Logics should relies on `SpeechRecognition.continuous` property than `continuous` props, by [@compulim](https://github.com/compulim), in PR [#87](https://github.com/compulim/react-dictate-button/pull/87)

## Specific changes

> Please list each individual specific change in this pull request.

- Fixed `dictate` event should dispatch before `end` event
- Updated tests to not honor `continuous` property
- Logics now relies on `SpeechRecognition.continuous` property