### PR TITLE
Fix `onEnd` event only emit after `SpeechRecognition.end` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ Breaking changes are indicated by 💥.
 
 - Fixed `dictate` event should dispatch before `end` event, by [@compulim](https://github.com/compulim), in PR [#87](https://github.com/compulim/react-dictate-button/pull/87)
 - Fixed [#84](https://github.com/compulim/react-dictate-button/issues/84). Logics should relies on `SpeechRecognition.continuous` property than `continuous` props, by [@compulim](https://github.com/compulim), in PR [#87](https://github.com/compulim/react-dictate-button/pull/87)
+- Fixed `end` event should only be dispatched after `SpeechRecognition.error` event, instead of always emit on stop/unmount, by [@compulim](https://github.com/compulim), in PR [#88](https://github.com/compulim/react-dictate-button/pull/88)
 
 ### Changed
 
 - Reduced React version requirement from 16.9.0 to 16.8.6, by [@compulim](https://github.com/compulim), in PR [#83](https://github.com/compulim/react-dictate-button/pull/83)
+- 💥 Stopping an unabortable recognition (`SpeechRecognition.abort()` is undefined) will warn instead of throw, by [@compulim](https://github.com/compulim), in PR [#88](https://github.com/compulim/react-dictate-button/pull/88)
 
 ## [3.0.0] - 2025-01-31
 

--- a/packages/react-dictate-button/__tests__/errorWithNoSpeech.tsx
+++ b/packages/react-dictate-button/__tests__/errorWithNoSpeech.tsx
@@ -1,0 +1,96 @@
+/** @jest-environment @happy-dom/jest-environment */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import {
+  DictateButton,
+  type DictateEventHandler,
+  type EndEventHandler,
+  type ErrorEventHandler,
+  type ProgressEventHandler,
+  type StartEventHandler
+} from '../src/index';
+import { SpeechRecognition, SpeechRecognitionErrorEvent } from '../src/internal';
+
+describe('with error of "no-speech"', () => {
+  let constructSpeechRecognition: jest.Mock<SpeechRecognition, []>;
+  let onDictate: jest.Mock<ReturnType<DictateEventHandler>, Parameters<DictateEventHandler>, undefined>;
+  let onEnd: jest.Mock<ReturnType<EndEventHandler>, Parameters<EndEventHandler>, undefined>;
+  let onError: jest.Mock<ReturnType<ErrorEventHandler>, Parameters<ErrorEventHandler>, undefined>;
+  let onProgress: jest.Mock<ReturnType<ProgressEventHandler>, Parameters<ProgressEventHandler>, undefined>;
+  let onStart: jest.Mock<ReturnType<StartEventHandler>, Parameters<StartEventHandler>, undefined>;
+  let start: jest.SpyInstance<void, [], SpeechRecognition> | undefined;
+
+  test('should dispatch events accordingly', () => {
+    constructSpeechRecognition = jest.fn().mockImplementationOnce(() => {
+      const speechRecognition = new SpeechRecognition();
+
+      start = jest.spyOn(speechRecognition, 'start');
+
+      return speechRecognition;
+    });
+
+    onDictate = jest.fn();
+    onEnd = jest.fn();
+    onError = jest.fn();
+    onProgress = jest.fn();
+    onStart = jest.fn();
+
+    render(
+      <DictateButton
+        continuous={true}
+        onDictate={onDictate}
+        onEnd={onEnd}
+        onError={onError}
+        onProgress={onProgress}
+        onStart={onStart}
+        speechGrammarList={window.SpeechGrammarList}
+        speechRecognition={constructSpeechRecognition}
+      >
+        Click me
+      </DictateButton>
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByText('Click me'));
+    });
+
+    const speechRecognition: SpeechRecognition = constructSpeechRecognition.mock.results[0]?.value;
+
+    expect(onProgress).toHaveBeenCalledTimes(0);
+    expect(start).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      speechRecognition.dispatchEvent(new Event('start', {}));
+      speechRecognition.dispatchEvent(new Event('audiostart', {}));
+    });
+
+    expect(onEnd).toHaveBeenCalledTimes(0);
+    expect(onStart).toHaveBeenCalledTimes(1);
+
+    onEnd.mockReset();
+    onStart.mockReset();
+
+    expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onProgress.mock.calls[0][0]).toHaveProperty('type', 'progress');
+    expect(onProgress.mock.calls[0][0]).not.toHaveProperty('results', expect.anything());
+
+    // ---
+
+    act(() => {
+      speechRecognition.dispatchEvent(new Event('audioend', {}));
+      speechRecognition.dispatchEvent(new SpeechRecognitionErrorEvent('error', { error: 'no-speech', message: '' }));
+      speechRecognition.dispatchEvent(new Event('end', {}));
+    });
+
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenLastCalledWith(expect.any(SpeechRecognitionErrorEvent));
+    expect(onError).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        error: 'no-speech',
+        type: 'error'
+      })
+    );
+  });
+});

--- a/packages/react-dictate-button/__tests__/stopAfterOnDictate.spec.tsx
+++ b/packages/react-dictate-button/__tests__/stopAfterOnDictate.spec.tsx
@@ -18,6 +18,8 @@ describe('with SpeechRecognition object without abort() stop after onDictate', (
   let start: jest.SpyInstance<void, [], SpeechRecognition> | undefined;
 
   beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
     constructSpeechRecognition = jest.fn().mockImplementationOnce(() => {
       const speechRecognition = new SpeechRecognition();
 
@@ -76,8 +78,17 @@ describe('with SpeechRecognition object without abort() stop after onDictate', (
       expect(onDictate).toHaveBeenCalledTimes(1);
     });
 
-    test('unmounting the button after onDictate should not throw', () => {
-      renderResult.rerender(<Fragment />);
+    describe('unmounting the button after onDictate', () => {
+      beforeEach(() => {
+        renderResult.rerender(<Fragment />);
+      });
+
+      test('should warn for unabortable recognition', () => {
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenLastCalledWith(
+          'react-dictate-state: Cannot stop because SpeechRecognition does not have abort() function.'
+        );
+      });
     });
   });
 

--- a/packages/react-dictate-button/__tests__/stopBeforeResult.spec.tsx
+++ b/packages/react-dictate-button/__tests__/stopBeforeResult.spec.tsx
@@ -1,0 +1,140 @@
+/** @jest-environment @happy-dom/jest-environment */
+
+import { act, fireEvent, render, screen, type RenderResult } from '@testing-library/react';
+import React from 'react';
+import {
+  DictateCheckbox,
+  type DictateEventHandler,
+  type EndEventHandler,
+  type ProgressEventHandler,
+  type StartEventHandler
+} from '../src/index';
+import {
+  SpeechRecognition,
+  SpeechRecognitionAlternative,
+  SpeechRecognitionEvent,
+  SpeechRecognitionResult,
+  SpeechRecognitionResultList
+} from '../src/internal';
+
+describe('when stopping recognition', () => {
+  let constructSpeechRecognition: jest.Mock<SpeechRecognition, []>;
+  let onDictate: jest.Mock<ReturnType<DictateEventHandler>, Parameters<DictateEventHandler>, undefined>;
+  let onEnd: jest.Mock<ReturnType<EndEventHandler>, Parameters<EndEventHandler>, undefined>;
+  let onProgress: jest.Mock<ReturnType<ProgressEventHandler>, Parameters<ProgressEventHandler>, undefined>;
+  let onStart: jest.Mock<ReturnType<StartEventHandler>, Parameters<StartEventHandler>, undefined>;
+  let renderResult: RenderResult;
+  let start: jest.SpyInstance<void, [], SpeechRecognition> | undefined;
+
+  beforeEach(() => {
+    constructSpeechRecognition = jest.fn().mockImplementationOnce(() => {
+      const speechRecognition = new SpeechRecognition();
+
+      start = jest.spyOn(speechRecognition, 'start');
+
+      return speechRecognition;
+    });
+
+    onDictate = jest.fn();
+    onEnd = jest.fn();
+    onProgress = jest.fn();
+    onStart = jest.fn();
+
+    renderResult = render(
+      <DictateCheckbox
+        onDictate={onDictate}
+        onEnd={onEnd}
+        onProgress={onProgress}
+        onStart={onStart}
+        speechGrammarList={window.SpeechGrammarList}
+        speechRecognition={constructSpeechRecognition}
+      >
+        Click me
+      </DictateCheckbox>
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByText('Click me'));
+    });
+
+    expect(constructSpeechRecognition).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  describe('when interim speech events are dispatched', () => {
+    beforeEach(() => {
+      act(() => {
+        const speechRecognition: SpeechRecognition = constructSpeechRecognition.mock.results[0]?.value;
+
+        speechRecognition.dispatchEvent(new Event('start', {}));
+        speechRecognition.dispatchEvent(new Event('audiostart', {}));
+        speechRecognition.dispatchEvent(new Event('soundstart', {}));
+        speechRecognition.dispatchEvent(new Event('speechstart', {}));
+
+        speechRecognition.dispatchEvent(
+          new SpeechRecognitionEvent('result', {
+            resultIndex: 0,
+            results: new SpeechRecognitionResultList(
+              new SpeechRecognitionResult(new SpeechRecognitionAlternative(0.9, 'Hello, World!'))
+            )
+          })
+        );
+      });
+    });
+
+    test('should not emit "onEnd"', () => expect(onEnd).toHaveBeenCalledTimes(0));
+    test('should emit "onStart"', () => expect(onStart).toHaveBeenCalledTimes(1));
+
+    test('should emit "onProgress" twice', () => {
+      expect(onProgress).toHaveBeenCalledTimes(2);
+
+      // From "audiostart" event, no "results".
+      expect(onProgress).toHaveBeenNthCalledWith(1, {
+        abortable: true,
+        type: 'progress'
+      });
+
+      // From "result" event with falsy "isFinal", no "results".
+      expect(onProgress).toHaveBeenNthCalledWith(2, {
+        abortable: true,
+        results: [{ confidence: 0.9, transcript: 'Hello, World!' }],
+        type: 'progress'
+      });
+    });
+
+    // The paired "dictate" event should only be dispatched immediately before "end" event.
+    test('should not emit "onDictate"', () => expect(onDictate).toHaveBeenCalledTimes(0));
+
+    describe('when checkbox is unchecked', () => {
+      beforeEach(() => {
+        act(() => {
+          fireEvent.click(screen.getByText('Click me'));
+        });
+      });
+
+      test('should not emit "onDictate"', () => expect(onDictate).toHaveBeenCalledTimes(0));
+      test('should not emit "onEnd"', () => expect(onEnd).toHaveBeenCalledTimes(0));
+
+      describe('when "end" event is dispatched', () => {
+        beforeEach(() => {
+          act(() => {
+            const speechRecognition: SpeechRecognition = constructSpeechRecognition.mock.results[0]?.value;
+
+            speechRecognition.dispatchEvent(new Event('speechend', {}));
+            speechRecognition.dispatchEvent(new Event('soundend', {}));
+            speechRecognition.dispatchEvent(new Event('audioend', {}));
+            speechRecognition.dispatchEvent(new Event('end', {}));
+          });
+        });
+
+        test('should emit "onEnd"', () => expect(onEnd).toHaveBeenCalledTimes(1));
+
+        // If "onProgress" is dispatched, a corresponding "onDictate" event must be dispatched in pair.
+        test('should emit "onDictate" without "result"', () => {
+          expect(onDictate).toHaveBeenCalledTimes(1);
+          expect(onDictate).toHaveBeenLastCalledWith({ type: 'dictate' });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Fixed

- Fixed `end` event should only be dispatched after `SpeechRecognition.error` event, instead of always emit on stop/unmount, by [@compulim](https://github.com/compulim), in PR [#88](https://github.com/compulim/react-dictate-button/pull/88)

### Changed

- 💥 Stopping an unabortable recognition (`SpeechRecognition.abort()` is undefined) will warn instead of throw, by [@compulim](https://github.com/compulim), in PR [#88](https://github.com/compulim/react-dictate-button/pull/88)

## Specific changes

> Please list each individual specific change in this pull request.

- Removed `emitEnd()` on `started` change or component unmounted
- Changed throw on abortable recognition to warn
- Added tests for `no-speech` error